### PR TITLE
Add new Tailwind 2xl breakpoint to default config

### DIFF
--- a/src/grids/tailwind.js
+++ b/src/grids/tailwind.js
@@ -4,4 +4,5 @@ export default {
   md: 768,
   lg: 1024,
   xl: 1280,
+  '2xl': 1536,
 };


### PR DESCRIPTION
This PR adds the new `2xl` breakpoint introduced in Tailwind CSS.

Reference: https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L13