### PR TITLE
fix extendGrid breakpoint issue

### DIFF
--- a/packages/lib/src/useGrid.ts
+++ b/packages/lib/src/useGrid.ts
@@ -9,24 +9,29 @@ import {
   GridObjectLiteral,
   SupportedGridType,
   CustomObject,
-  ComputedBreakpoint
+  ComputedBreakpoint,
 } from './types/grid'
 import grids from './grids'
 import { reactive, onUnmounted, getCurrentInstance } from 'vue'
-import { inBrowser, debounce } from './utils'
+import { inBrowser, debounce, remAndEmToPixels } from './utils'
 
 export const DEFAULT_GRID_FRAMEWORK = 'tailwind'
 
 export const createGridObject = <T extends GridTypes>(config: GridType<T>): GridObject<T> => {
-  return Object.keys(config).reduce((accumulator, key) => {
-    accumulator[key] = false
-    return accumulator
-  }, {
-    breakpoint: '',
-  } as GridObject<T>)
+  return Object.keys(config).reduce(
+    (accumulator, key) => {
+      accumulator[key] = false
+      return accumulator
+    },
+    {
+      breakpoint: '',
+    } as GridObject<T>
+  )
 }
 
-export const createConfigFromLiteral = (literal: GridDefinitionLiteral): GridTypeLiteral<GridDefinitionLiteral> => {
+export const createConfigFromLiteral = (
+  literal: GridDefinitionLiteral
+): GridTypeLiteral<GridDefinitionLiteral> => {
   if (!grids[literal]) {
     throw new Error(`Invalid grid type "${literal}"`)
   }
@@ -34,18 +39,24 @@ export const createConfigFromLiteral = (literal: GridDefinitionLiteral): GridTyp
   return grids[literal]
 }
 
-export const getCurrentBreakpoint = (config: Custom, object: CustomObject): string => {
+export const getCurrentBreakpoint = (
+  config: Custom,
+  object: CustomObject
+): string => {
   const current = Object.keys(object)
-    .filter(key => {
+    .filter((key) => {
       return !['breakpoint'].includes(key) && typeof config[key] !== 'function'
     })
-    .reverse()
-    .find(key => object[key])
+    .sort((a, b) => parseInt(`${config[b]}`) - parseInt(`${config[a]}`))
+    .find((key) => object[key])
   return current || ''
 }
 
-/* istanbul ignore next  */
-export const updateComputedProperties = (config: Custom, object: CustomObject): void => {
+/* istanbul ignore next */
+export const updateComputedProperties = (
+  config: Custom,
+  object: CustomObject & { breakpoint: keyof CustomObject }
+): void => {
   Object.keys(config)
     .filter((breakpoint) => {
       return typeof config[breakpoint] === 'function'
@@ -53,13 +64,19 @@ export const updateComputedProperties = (config: Custom, object: CustomObject): 
     .forEach((breakpoint) => {
       const fn = config[breakpoint] as ComputedBreakpoint
       object[breakpoint] = fn.call(null, object)
+      if (object[breakpoint] && !object.breakpoint) {
+        object.breakpoint = breakpoint
+      }
     })
 }
 
 const debouncedUpdateComputedProperties = debounce(updateComputedProperties, 100)
 
-/* istanbul ignore next  */
-export const createMediaQueries = (config: Custom, object: CustomObject & { breakpoint: keyof CustomObject }): void => {
+/* istanbul ignore next */
+export const createMediaQueries = (
+  config: Custom,
+  object: CustomObject & { breakpoint: keyof CustomObject }
+): void => {
   Object.keys(config)
     .filter((breakpoint) => {
       return typeof config[breakpoint] !== 'function'
@@ -81,7 +98,7 @@ export const createMediaQueries = (config: Custom, object: CustomObject & { brea
 
       const query = window.matchMedia(`(min-width: ${width})`)
       if ('addEventListener' in query) {
-        query.addEventListener('change', onChange);
+        query.addEventListener('change', onChange)
       } else {
         // https://github.com/reegodev/vue-screen/issues/30
         // query.addListener is not deprecated for iOS 12
@@ -97,7 +114,7 @@ export const createMediaQueries = (config: Custom, object: CustomObject & { brea
       if (getCurrentInstance()) {
         onUnmounted(() => {
           if ('removeEventListener' in query) {
-            query.removeEventListener('change', onChange);
+            query.removeEventListener('change', onChange)
           } else {
             // https://github.com/reegodev/vue-screen/issues/30
             // query.removeListener is not deprecated for iOS 12
@@ -111,9 +128,9 @@ export const createMediaQueries = (config: Custom, object: CustomObject & { brea
   updateComputedProperties(config, object)
 }
 
-export function useGrid<T extends GridDefinitionLiteral> (gridConfig: T): GridObjectLiteral<T>
-export function useGrid<T extends GridDefinitionCustomObject> (gridConfig: T): GridObject<T>
-export function useGrid (
+export function useGrid<T extends GridDefinitionLiteral>(gridConfig: T): GridObjectLiteral<T>
+export function useGrid<T extends GridDefinitionCustomObject>(gridConfig: T): GridObject<T>
+export function useGrid(
   gridConfig: GridDefinitionLiteral | GridDefinitionCustomObject = DEFAULT_GRID_FRAMEWORK
 ): Readonly<GridObjectLiteral<GridDefinitionLiteral>> | Readonly<GridObject<any>> {
   let config: Custom | SupportedGridType
@@ -121,12 +138,25 @@ export function useGrid (
   if (typeof gridConfig === 'string') {
     config = createConfigFromLiteral(gridConfig as GridDefinitionLiteral)
   } else {
-    config = Object.assign(gridConfig as GridDefinitionCustomObject)
+    // convert rem / em to pixels so we can sort breakpoints correctly
+    config = Object.keys(gridConfig).reduce((acc, curr) => {
+      const unitValue = gridConfig[curr]
+      if (
+        typeof unitValue === 'string' &&
+        (unitValue.includes('rem') || unitValue.includes('em'))
+      ) {
+        acc[curr] = remAndEmToPixels(parseInt(unitValue))
+        return acc
+      }
+
+      acc[curr] = gridConfig[curr]
+      return acc
+    }, {})
   }
 
   const gridObject = reactive(createGridObject(config))
 
-  /* istanbul ignore if  */
+  /* istanbul ignore if */
   if (inBrowser) {
     createMediaQueries(config as Custom, gridObject)
   }
@@ -134,6 +164,13 @@ export function useGrid (
   return gridObject
 }
 
-export const extendGrid = <T extends GridDefinitionLiteral>(literalConfig: T, extraProperties: GridDefinitionCustomObject): GridDefinitionCustomObject => {
-  return Object.assign({}, createConfigFromLiteral(literalConfig), extraProperties)
+export const extendGrid = <T extends GridDefinitionLiteral>(
+  literalConfig: T,
+  extraProperties: GridDefinitionCustomObject
+): GridDefinitionCustomObject => {
+  return Object.assign(
+    {},
+    createConfigFromLiteral(literalConfig),
+    extraProperties
+  )
 }

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -17,3 +17,7 @@ export const debounce = (callback: (...params: unknown[]) => unknown, wait: numb
     timeout = setTimeout(later, wait);
   };
 };
+
+export const remAndEmToPixels = (value: number): number => {
+  return value * 16
+}


### PR DESCRIPTION
Hi

I've experienced a couple of issues when using extendGrid and thought I'd try fixing them

Issue 1: Passing in a number or string value when extending the grid causes the `grid.breakpoint` value to always be equal to the extended value e.g 

```
const grid = useGrid(extendGrid('tailwind', {
 xs: 500,
})
```

**_grid_** is now equal to the object below no matter what the screen size is

`{ breakpoint: 'xs', xs: true, sm: true, md: true, lg: false, xl: false, 2xl: false }`

Issue 2: Passing in a ComputedBreakpoint function causes the `grid.breakpoint` to be an empty string when the conditions are met. I'd expect the value of `grid.breakpoint` to be equal to the extended property

```
const grid = useGrid(extendGrid('tailwind', {
 xs: (grid) => !grid.lg,
})
```