### PR TITLE
Improvements Bootstrap docs

### DIFF
--- a/packages/docs/src/guide/configuration/composition-api.md
+++ b/packages/docs/src/guide/configuration/composition-api.md
@@ -51,7 +51,7 @@ useGrid(config: string)
 The value can either be a string literal, with one of the supported UI frameworks:
 
 ```ts
-'tailwind' | 'bootstrap' | 'bulma' | 'foundation' | 'materialize' | 'semanticUi'
+'tailwind' | 'bootstrap' | 'bootstrap4' | 'bootstrap5' | 'bulma' | 'foundation' | 'materialize' | 'semanticUi'
 ```
 
 or an object that specifies a custom grid:

--- a/packages/docs/src/guide/configuration/plugin.md
+++ b/packages/docs/src/guide/configuration/plugin.md
@@ -19,7 +19,7 @@ Config can be either:
 - a string, with one of the supported UI frameworks:
 
 ```ts
-'tailwind' | 'bootstrap' | 'bulma' | 'foundation' | 'materialize' | 'semanticUi'
+'tailwind' | 'bootstrap' | 'bootstrap4' | 'bootstrap5' | 'bulma' | 'foundation' | 'materialize' | 'semanticUi'
 ```
 
 - an object, with the following signature:

--- a/packages/docs/src/guide/frameworks/bootstrap.md
+++ b/packages/docs/src/guide/frameworks/bootstrap.md
@@ -6,7 +6,7 @@ editLink: true
 
 To use Bootstrap as your UI framework, simply pass it to the configuration
 
-### Boostrap 3
+### Bootstrap 3
 ```js
 import { useGrid } from 'vue-screen'
 
@@ -32,7 +32,7 @@ import VueScreen from 'vue-screen'
 createApp().use(VueScreen, 'bootstrap') // Bootstrap 3 grid
 ```
 
-### Boostrap 4
+### Bootstrap 4
 ```js
 import { useGrid } from 'vue-screen'
 
@@ -45,7 +45,7 @@ import VueScreen from 'vue-screen'
 createApp().use(VueScreen, 'bootstrap4')
 ```
 
-### Boostrap 5
+### Bootstrap 5
 ```js
 import { useGrid } from 'vue-screen'
 

--- a/packages/docs/src/guide/frameworks/bootstrap.md
+++ b/packages/docs/src/guide/frameworks/bootstrap.md
@@ -6,7 +6,7 @@ editLink: true
 
 To use Bootstrap as your UI framework, simply pass it to the configuration
 
-### Bootstrap 3
+## Bootstrap 3
 ```js
 import { useGrid } from 'vue-screen'
 
@@ -32,7 +32,19 @@ import VueScreen from 'vue-screen'
 createApp().use(VueScreen, 'bootstrap') // Bootstrap 3 grid
 ```
 
-### Bootstrap 4
+Your grid object will contain the following properties:
+
+```ts
+{
+  xs: boolean,
+  sm: boolean,
+  md: boolean,
+  lg: boolean,
+  breakpoint: string | null // the current breakpoint
+}
+```
+
+## Bootstrap 4
 ```js
 import { useGrid } from 'vue-screen'
 
@@ -45,7 +57,20 @@ import VueScreen from 'vue-screen'
 createApp().use(VueScreen, 'bootstrap4')
 ```
 
-### Bootstrap 5
+Your grid object will contain the following properties:
+
+```ts
+{
+  xs: boolean,
+  sm: boolean,
+  md: boolean,
+  lg: boolean,
+  xl: boolean
+  breakpoint: string | null // the current breakpoint
+}
+```
+
+## Bootstrap 5
 ```js
 import { useGrid } from 'vue-screen'
 
@@ -61,26 +86,6 @@ createApp().use(VueScreen, 'bootstrap5')
 Your grid object will contain the following properties:
 
 ```ts
-// Bootstrap 3
-{
-  xs: boolean,
-  sm: boolean,
-  md: boolean,
-  lg: boolean,
-  breakpoint: string | null // the current breakpoint
-}
-
-// Bootstrap 4
-{
-  xs: boolean,
-  sm: boolean,
-  md: boolean,
-  lg: boolean,
-  xl: boolean
-  breakpoint: string | null // the current breakpoint
-}
-
-// Bootstrap 5
 {
   xs: boolean,
   sm: boolean,


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

Thank you for this package.

This PR proposes a few improvements to:

the Bootstrap docs page:
- fixes a few typos
- structure & markup: 
  - moves the grid object properties examples to the section for a specific Bootstrap version. This way all info related to a specific version is contained in one section
  - changed h3 headers to h2 headers, so the section titles end up in the menu on the right side of the page

The configuration section: added config options `bootstrap4`  and `bootstrap5`.

I've created separate commits for typos and the rest of the changes, so you can easily revert the markup changes in case you don't agree.