### PR TITLE
feat: augment `vue` instead of `@vue/runtime-core`

### DIFF
--- a/packages/lib/src/plugin.ts
+++ b/packages/lib/src/plugin.ts
@@ -3,7 +3,7 @@ import { useScreen } from './useScreen'
 import { VueScreenConfig } from './types/config'
 import { useGrid } from './useGrid'
 
-export const install = (app: App, options: VueScreenConfig): void => {
+export const install = (app: App, options?: VueScreenConfig): void => {
   let screen
   let grid
 

--- a/packages/lib/src/types/config.ts
+++ b/packages/lib/src/types/config.ts
@@ -6,7 +6,7 @@ export type GettersDefinition = Record<string, (screen: ScreenObject) => unknown
 export type VueScreenConfigLiteral = GridDefinitionLiteral
 
 export interface VueScreenConfigObject {
-  grid: GridDefinition
+  grid?: GridDefinition
   ssr?: ScreenConfig,
   // getters?: GettersDefinition
   debounceDelay?: number

--- a/packages/lib/src/types/grid.ts
+++ b/packages/lib/src/types/grid.ts
@@ -80,7 +80,7 @@ export type GridDefinitionLiteral =
 export type GridDefinition = GridDefinitionLiteral | GridDefinitionCustomObject
 
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $grid: Readonly<Record<keyof Custom, boolean> & BaseObject<Custom>>
   }

--- a/packages/lib/src/types/screen.ts
+++ b/packages/lib/src/types/screen.ts
@@ -15,7 +15,7 @@ export interface ScreenConfig {
   touch?: boolean
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $screen: Readonly<ScreenObject>
   }


### PR DESCRIPTION
After [vuejs/core#11609](https://www.github.com/vuejs/core/pull/11609) vue supports adding custom properties using `declare module 'vue'` 
instead of `declare module '@vue/runtime-core'`

Having libraries in a project that augment both `vue` and `@vue/runtime-core` breaks type checking. 
More info: [Vue TypeScript Changes - nuxt.com/blog](https://nuxt.com/blog/v3-13#vue-typescript-changes)

In this PR: 

- replace `declare module '@vue/runtime-core'` with `declare module 'vue'`
- fix `install()` and `VueScreenConfigObject` types.
   Otherwise tests did not pass with `No overload matches this call` ts error