### PR TITLE
fix: augment `vue` rather than`@vue/runtime-core`

### DIFF
--- a/packages/lib/src/types/grid.ts
+++ b/packages/lib/src/types/grid.ts
@@ -80,7 +80,7 @@ export type GridDefinitionLiteral =
 export type GridDefinition = GridDefinitionLiteral | GridDefinitionCustomObject
 
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $grid: Readonly<Record<keyof Custom, boolean> & BaseObject<Custom>>
   }

--- a/packages/lib/src/types/screen.ts
+++ b/packages/lib/src/types/screen.ts
@@ -15,7 +15,7 @@ export interface ScreenConfig {
   touch?: boolean
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $screen: Readonly<ScreenObject>
   }


### PR DESCRIPTION
This PR removes augmentations of`@vue/runtime-core` in favour of only augmenting`vue`(the new recommendation), which should fix issues when other packages are only augmenting vue(see nuxt / nuxt#28542).